### PR TITLE
Improve Cubee AI action tracking

### DIFF
--- a/games/Cube/Game/dao.py
+++ b/games/Cube/Game/dao.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     init_db()
 
     # Exemple d'utilisation
-    unique_key = generate_key('A1', 'B2', 'C3', 'D4', 'matrix_state', 'board_state')
+    unique_key = generate_key('A1', 'B2', 'C3', 'D4', 'matrix_state', 'board_state', 'action')
     entry_dto = {'unique_key': unique_key, 'reward': 0.5}
     save_entry(entry_dto)
 

--- a/games/Cube/Game/dico.py
+++ b/games/Cube/Game/dico.py
@@ -1,2 +1,7 @@
-def generate_key(x, y, ennemy_x, ennemy_y, matrix, board):
-    return f"{x},{y},{ennemy_x},{ennemy_y},{matrix},{board}"
+def generate_key(x, y, ennemy_x, ennemy_y, matrix, board, action):
+    """Genère une clé unique pour l'état/action.
+
+    Cette fonction sert d'index dans la Q-table pour permettre à l'IA de
+    retrouver la valeur associée à un couple (état, action).
+    """
+    return f"{x},{y},{ennemy_x},{ennemy_y},{matrix},{board},{action}"

--- a/games/Cube/Game/game_models/players.py
+++ b/games/Cube/Game/game_models/players.py
@@ -83,8 +83,15 @@ class AiPlayer(Player):
         for dx, dy in actions:
             nx, ny = self.x + dx, self.y + dy
             if 0 <= nx < self.board.size and 0 <= ny < self.board.size:
-                key = generate_key(self.x, self.y, self.enemy.x, self.enemy.y, self.board.get_matrix_state(),
-                                   self.board.get_board_state())
+                key = generate_key(
+                    self.x,
+                    self.y,
+                    self.enemy.x,
+                    self.enemy.y,
+                    self.board.get_matrix_state(),
+                    self.board.get_board_state(),
+                    (dx, dy),
+                )
                 q_value = self.get_q_value(key)
                 if q_value > best_value:
                     best_value = q_value
@@ -96,12 +103,28 @@ class AiPlayer(Player):
         Met à jour la table Q avec la nouvelle valeur calculée
         """
         # Génère les clés pour l'état actuel et suivant
-        current_key = generate_key(*state)
-        next_key = generate_key(*next_state)
+        current_key = generate_key(*state, action)
+
+        # Calcul du meilleur Q pour l'état suivant sur toutes les actions
+        possible_actions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        next_q_values = [
+            self.get_q_value(
+                generate_key(
+                    next_state[0],
+                    next_state[1],
+                    next_state[2],
+                    next_state[3],
+                    next_state[4],
+                    next_state[5],
+                    a,
+                )
+            )
+            for a in possible_actions
+        ]
+        next_q = max(next_q_values)
 
         # Obtient les valeurs Q actuelles
         current_q = self.get_q_value(current_key)
-        next_q = self.get_q_value(next_key)
 
         # Calcule la nouvelle valeur Q
         new_q = current_q + self.lr * (reward + self.gamma * next_q - current_q)


### PR DESCRIPTION
## Summary
- make generate_key include the action
- adapt DAO example and AI player logic to use action-based key
- compute best Q value over all actions when updating Q-table

## Testing
- `pytest -q` *(fails: test_enclosure[board_matrix2-2-expected2])*

------
https://chatgpt.com/codex/tasks/task_e_684059793aa8832788e745572f787379