### PR TITLE
Improve Cubee learning and enclosure logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Pour jouer contre un autre joueur, modifiez la classe Player en HumanPlayer pour
 ```
 games/Cube/main.py
 ```
+
+### Entraîner l'IA Cubee
+
+La fonction `GameController.training` permet de lancer une série de parties entre deux IA sans interface afin d'améliorer leur Q-table. Elle se trouve dans `games/Cube/Game/game_controller.py`.
+
+```python
+from Game.game_models.players import AiPlayer
+from Game.game_controller import GameController
+
+ai1 = AiPlayer(name="IA_1", color="blue")
+ai2 = AiPlayer(name="IA_2", color="red")
+
+GameController.training(ai1, ai2, board=3, nb_games=5000, epsilon=10)
+GameController.compare_ai(ai1, ai2)
+```
 ### Allumettes
 
 Par défaut, vous jouez contre une IA.

--- a/games/Cube/Game/dao.py
+++ b/games/Cube/Game/dao.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     init_db()
 
     # Exemple d'utilisation
-    unique_key = generate_key('A1', 'B2', 'C3', 'D4', 'matrix_state', 'board_state')
+    unique_key = generate_key('A1', 'B2', 'C3', 'D4', 'matrix_state', 'board_state', 'action')
     entry_dto = {'unique_key': unique_key, 'reward': 0.5}
     save_entry(entry_dto)
 

--- a/games/Cube/Game/dico.py
+++ b/games/Cube/Game/dico.py
@@ -1,2 +1,7 @@
-def generate_key(x, y, ennemy_x, ennemy_y, matrix, board):
-    return f"{x},{y},{ennemy_x},{ennemy_y},{matrix},{board}"
+def generate_key(x, y, ennemy_x, ennemy_y, matrix, board, action):
+    """Genère une clé unique pour l'état/action.
+
+    Cette fonction sert d'index dans la Q-table pour permettre à l'IA de
+    retrouver la valeur associée à un couple (état, action).
+    """
+    return f"{x},{y},{ennemy_x},{ennemy_y},{matrix},{board},{action}"

--- a/games/Cube/Game/game_models/game_model.py
+++ b/games/Cube/Game/game_models/game_model.py
@@ -73,15 +73,21 @@ class GameModel:
         return self.current_player
 
     def moove(self, bind):
-        if (bind == 'UP') and self.can_move(self.current_player.x, self.current_player.y - 1):
+        player = self.current_player
+
+        if (bind == 'UP') and self.can_move(player.x, player.y - 1):
             self.move_up()
-        elif (bind == 'DOWN') and self.can_move(self.current_player.x, self.current_player.y + 1):
+        elif (bind == 'DOWN') and self.can_move(player.x, player.y + 1):
             self.move_down()
-        elif (bind == 'LEFT') and self.can_move(self.current_player.x - 1, self.current_player.y):
+        elif (bind == 'LEFT') and self.can_move(player.x - 1, player.y):
             self.move_left()
-        elif (bind == 'RIGHT') and self.can_move(self.current_player.x + 1, self.current_player.y):
+        elif (bind == 'RIGHT') and self.can_move(player.x + 1, player.y):
             self.move_right()
+
         self.check_enclosure()
+
+        if hasattr(player, "after_move"):
+            player.after_move()
 
     def move_up(self):
         self.current_player.y -= 1
@@ -199,18 +205,38 @@ class GameModel:
         player = self.current_player
         opponent = self.players1 if self.current_player == self.players2 else self.players2
 
+        # Travail sur une copie pour éviter de modifier une matrice partagée
+        self.matrix = [[cell.copy() for cell in row] for row in self.matrix]
+        matrix = self.matrix
+
         reachable = [[False for _ in range(self.board)] for _ in range(self.board)]
-        queue = [(player.x, player.y)]
+        queue = []
+
+        for x in range(self.board):
+            for y in range(self.board):
+                if matrix[x][y]["color"] == player.color:
+                    reachable[x][y] = True
+                    queue.append((x, y))
+
+        if not reachable[player.x][player.y]:
+            reachable[player.x][player.y] = True
+            queue.append((player.x, player.y))
 
         while queue:
             x, y = queue.pop(0)  
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
                 nx, ny = x + dx, y + dy
-                if (0 <= nx < self.board and 0 <= ny < self.board and
-                    not reachable[nx][ny] and 
-                    (self.matrix[nx][ny]["color"] == "white" or self.matrix[nx][ny]["color"] == player.color)):
+                if (
+                    0 <= nx < self.board
+                    and 0 <= ny < self.board
+                    and not reachable[nx][ny]
+                    and (
+                        matrix[nx][ny]["color"] == "white"
+                        or matrix[nx][ny]["color"] == player.color
+                    )
+                ):
                     reachable[nx][ny] = True
-                    queue.append((nx, ny))  
+                    queue.append((nx, ny))
 
         for x in range(self.board):
             for y in range(self.board):

--- a/games/Cube/Game/game_models/players.py
+++ b/games/Cube/Game/game_models/players.py
@@ -83,8 +83,15 @@ class AiPlayer(Player):
         for dx, dy in actions:
             nx, ny = self.x + dx, self.y + dy
             if 0 <= nx < self.board.size and 0 <= ny < self.board.size:
-                key = generate_key(self.x, self.y, self.enemy.x, self.enemy.y, self.board.get_matrix_state(),
-                                   self.board.get_board_state())
+                key = generate_key(
+                    self.x,
+                    self.y,
+                    self.enemy.x,
+                    self.enemy.y,
+                    self.board.get_matrix_state(),
+                    self.board.get_board_state(),
+                    (dx, dy),
+                )
                 q_value = self.get_q_value(key)
                 if q_value > best_value:
                     best_value = q_value
@@ -96,12 +103,28 @@ class AiPlayer(Player):
         Met à jour la table Q avec la nouvelle valeur calculée
         """
         # Génère les clés pour l'état actuel et suivant
-        current_key = generate_key(*state)
-        next_key = generate_key(*next_state)
+        current_key = generate_key(*state, action)
+
+        # Calcul du meilleur Q pour l'état suivant sur toutes les actions
+        possible_actions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        next_q_values = [
+            self.get_q_value(
+                generate_key(
+                    next_state[0],
+                    next_state[1],
+                    next_state[2],
+                    next_state[3],
+                    next_state[4],
+                    next_state[5],
+                    a,
+                )
+            )
+            for a in possible_actions
+        ]
+        next_q = max(next_q_values)
 
         # Obtient les valeurs Q actuelles
         current_q = self.get_q_value(current_key)
-        next_q = self.get_q_value(next_key)
 
         # Calcule la nouvelle valeur Q
         new_q = current_q + self.lr * (reward + self.gamma * next_q - current_q)
@@ -126,29 +149,49 @@ class AiPlayer(Player):
         return None
 
     def play(self):
-        old_x, old_y = self.x, self.y
-        old_state = (self.x, self.y, self.enemy.x, self.enemy.y,
-                     self.board.get_matrix_state(), self.board.get_board_state())
+        """Choisit une action et la renvoie sous forme de direction."""
 
-        action = self.choose_action()
-        direction = self.action_to_direction(action)
+        # Mémorise l'état avant déplacement pour la mise à jour après le coup
+        self._old_state = (
+            self.x,
+            self.y,
+            self.enemy.x,
+            self.enemy.y,
+            self.board.get_matrix_state(),
+            self.board.get_board_state(),
+        )
 
-        # Calcule la nouvelle position sans l'appliquer
-        dx, dy = action
-        new_x, new_y = self.x + dx, self.y + dy
-
-        # Calcule la récompense
-        reward = self.calculate_reward(old_x, old_y, new_x, new_y)
-
-        # Calcule le nouvel état sans l'appliquer
-        new_state = (new_x, new_y, self.enemy.x, self.enemy.y,
-                     self.board.get_matrix_state(), self.board.get_board_state())
-
-        # Met à jour la table Q
-        self.update_q_table(old_state, action, reward, new_state)
-        print(f"Reward: {reward}, Action: {direction}")
+        # Choix de l'action
+        self._last_action = self.choose_action()
+        direction = self.action_to_direction(self._last_action)
 
         return direction
+
+    def after_move(self):
+        """Mise à jour de la Q-table une fois le déplacement effectué."""
+
+        dx, dy = self._last_action
+        new_x, new_y = self.x, self.y
+
+        reward = self.calculate_reward(
+            self._old_state[0],
+            self._old_state[1],
+            new_x,
+            new_y,
+        )
+
+        new_state = (
+            new_x,
+            new_y,
+            self.enemy.x,
+            self.enemy.y,
+            self.board.get_matrix_state(),
+            self.board.get_board_state(),
+        )
+
+        self.update_q_table(self._old_state, self._last_action, reward, new_state)
+        direction = self.action_to_direction(self._last_action)
+        print(f"Reward: {reward}, Action: {direction}")
 
     def calculate_reward(self, from_x, from_y, to_x, to_y):
         """
@@ -167,7 +210,7 @@ class AiPlayer(Player):
             return -50  # Pénalité pour un mouvement invalide
 
         # Vérifier si la case est occupée par l'adversaire
-        if self.board.matrix[to_x][to_y] == self.enemy.color:
+        if self.board.matrix[to_x][to_y]["color"] == self.enemy.color:
             return -50
 
         # Pénalité si on s'éloigne du centre


### PR DESCRIPTION
## Summary
- fix reward and update logic for the AI
- update Q-table after the board changes
- start enclosure BFS from every piece
- avoid mutating shared boards and call after_move
- document Cubee training in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684059793aa8832788e745572f787379